### PR TITLE
Fix for Suspicious Action pages when modifying bugs.

### DIFF
--- a/bugz/bugzilla.py
+++ b/bugz/bugzilla.py
@@ -539,7 +539,7 @@ class Bugz:
 
 		# copy existing fields
 		FIELDS = ('bug_file_loc', 'bug_severity', 'short_desc', 'bug_status',
-				'status_whiteboard', 'keywords',
+				'status_whiteboard', 'keywords', 'token',
 				'op_sys', 'priority', 'version', 'target_milestone',
 				'assigned_to', 'rep_platform', 'product', 'component', 'token')
 


### PR DESCRIPTION
Hi!

I have tried using PyBugz together with BugZilla 3.6.2 and could not modify bugs. I got to a
"Suspicious Action" page that said I might have just typed the URL in, the page asked me
to confirm the changes I requested.

There is a form field called "token" which is in newer versions of BugZilla, adding it to the
FIELDS which Bugz.get() extracts solved the entire issue.
