### PR TITLE
Issue #12: Add support for defaults in the configuration file

### DIFF
--- a/bin/bugz
+++ b/bin/bugz
@@ -288,6 +288,22 @@ def config_option(parser, get, section, option):
 			print " ! Error: option "+option+" is not in the right format: "+str(e)
 			sys.exit(1)
 
+def fill_config_option(bugz, parser, get, section, option):
+	value = config_option(parser, get, section, option)
+	if value is not None:
+		bugz[option] = value
+
+def fill_config(bugz, parser, section):
+	fill_config_option(bugz, parser, parser.get, section, 'base')
+	fill_config_option(bugz, parser, parser.get, section, 'user')
+	fill_config_option(bugz, parser, parser.get, section, 'password')
+	fill_config_option(bugz, parser, parser.get, section, 'httpuser')
+	fill_config_option(bugz, parser, parser.get, section, 'httppassword')
+	fill_config_option(bugz, parser, parser.get, section, 'forget')
+	fill_config_option(bugz, parser, parser.get, section, 'columns')
+	fill_config_option(bugz, parser, parser.get, section, 'encoding')
+	fill_config_option(bugz, parser, parser.get, section, 'quiet')
+
 def get_config(args, bugz):
 	config_file = getattr(args, 'config_file')
 	if config_file is None:
@@ -314,22 +330,15 @@ def get_config(args, bugz):
 		print " ! Error: Can't parse user configuration file: "+str(e)
 		sys.exit(1)
 
+	# parse the default section first
+	if "default" in sections:
+		fill_config(bugz, parser, "default")
+	if section is None:
+		section = config_option(parser, parser.get, "default", "connection")
+
 	# parse a specific section
 	if section in sections:
-		bugz['base'] = config_option(parser, parser.get, section, "base")
-		bugz['user'] = config_option(parser, parser.get, section, "user")
-		bugz['password'] = config_option(parser, parser.get, section, "password")
-		bugz['httpuser'] = config_option(parser, parser.get, section, "httpuser")
-		bugz['httppassword'] = config_option(parser, parser.get, section,
-				"httppassword")
-		bugz['forget'] = config_option(parser, parser.getboolean, section,
-				"forget")
-		bugz['columns'] = config_option(parser, parser.getint, section,
-				"columns")
-		bugz['encoding'] = config_option(parser, parser.get, section,
-				"encoding")
-		bugz['quiet'] = config_option(parser, parser.getboolean, section,
-				"quiet")
+		fill_config(bugz, parser, section)
 	elif section is not None:
 		print " ! Error: Can't find section ["+section+"] in configuration file"
 		sys.exit(1)

--- a/bugzrc.example
+++ b/bugzrc.example
@@ -22,4 +22,15 @@
 # columns: 80
 # encoding: utf-8
 # quiet: True
+#
+# The special section named 'default' may also be used. Other sections will
+# override any values specified here. The optional special key 'connection' is
+# used to name the default connection, to use when no --connection parameter is
+# specified to the bugz command.
+#
+# [default]
+# connection: sectionname
+# httpuser: xyz
+# httppassword: secret2
+# etc.
 


### PR DESCRIPTION
There's a new (optional) section named [default], which can contain any of the
keys that other sections can. These are used by default, and overridden by the
explicitly named sections.

A special key named 'connection' may also be present, which sets the name of
the default section to use when no --connection parameter is used on the
command line.
