### PR TITLE
Fix "no status named 'None'" error on modify

### DIFF
--- a/bugz/bugzilla.py
+++ b/bugz/bugzilla.py
@@ -605,6 +605,10 @@ class Bugz:
 			qparams['assigned_to'] = assigned_to
 			modified.append(('assigned_to', assigned_to))
 
+		# update status
+		if status is not None:
+			qparams['bug_status'] = status
+
 		# setup modification of other bits
 		if comment:
 			qparams['comment'] = comment


### PR DESCRIPTION
Attempting to 'modify' a bug would yield the error:
    There is no status named 'None'.

Now, 'None' status's are not sent to the server.

Seems related to 4594c54ea5 and
http://code.google.com/p/pybugz/issues/detail?id=27
