### PR TITLE
Converting columns to integers

### DIFF
--- a/bin/bugz
+++ b/bin/bugz
@@ -357,6 +357,8 @@ def get_kwds(args, bugz, cmd):
 				bugz[attr] = getattr(args,attr)
 		else:
 			cmd[attr] = getattr(args,attr)
+	if not type(bugz['columns']) == int:
+		bugz['columns'] = int(bugz['columns'])
 
 def main():
 	parser = make_parser()


### PR DESCRIPTION
Hi,

If columns is set in the config file it is read in as a string, which causes complaints when (self.columns - 1) is attempted.

Perhaps this is clumsy.... can you think of a better fix?
