### PR TITLE
Added standard values for 'op_sys' and 'platform' parameters.

### DIFF
--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -446,6 +446,8 @@ class PrettyBugz:
 		params['component'] = args.component
 		params['version'] = args.version
 		params['summary'] = args.summary
+                params['op_sys'] = "All"
+                params['platform'] = "All"
 		if args.description is not None:
 			params['description'] = args.description
 		if args.priority is not None:


### PR DESCRIPTION
Some bugzilla installations demand these two parameters explicitly
 given when submitting bugs. The parameters are both set to 'All' as this
 should fit most installations.
