### PR TITLE
Added options and arguments for 'op_sys' and 'platform'.

### DIFF
--- a/bugz/argparsers.py
+++ b/bugz/argparsers.py
@@ -184,6 +184,12 @@ def make_post_parser(subparsers):
 		help = 'description from contents of file')
 	post_parser.add_argument('--append-command',
 		help = 'append the output of a command to the description')
+	post_parser.add_argument('--os',
+		help = 'set the operating system',
+		dest = 'os')
+	post_parser.add_argument('--platform',
+		help = 'set the hardware platform',
+                dest = 'platform')
 	post_parser.add_argument('--batch',
 		action="store_true",
 		help = 'do not prompt for any values')

--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -446,6 +446,10 @@ class PrettyBugz:
 		params['component'] = args.component
 		params['version'] = args.version
 		params['summary'] = args.summary
+		if args.os is not None:
+			params['op_sys'] = args.os
+		if args.platform is not None:
+			params['platform'] = args.platform
 		if args.description is not None:
 			params['description'] = args.description
 		if args.priority is not None:

--- a/bugz/configfile.py
+++ b/bugz/configfile.py
@@ -18,10 +18,12 @@ def config_option(parser, get, section, option):
 
 def fill_config_option(args, parser, get, section, option):
 	value = config_option(parser, get, section, option)
-	if value is not None:
+        if value is not None:
 		setattr(args, option, value)
 
 def fill_config(args, parser, section):
+	fill_config_option(args, parser, parser.get, section, 'os')
+	fill_config_option(args, parser, parser.get, section, 'platform')
 	fill_config_option(args, parser, parser.get, section, 'base')
 	fill_config_option(args, parser, parser.get, section, 'user')
 	fill_config_option(args, parser, parser.get, section, 'password')

--- a/bugzrc.example
+++ b/bugzrc.example
@@ -48,6 +48,14 @@
 #
 # quiet: True
 #
+# Some bugzilla installations need to have the operating system and platform
+# specified explicitly when submitting new bugs, other don't. You can do so
+# via arguments or in the config file.
+#
+# os: All
+# platform: All
+#
+#
 # The special section named 'default' may also be used. Other sections will
 # override any values specified here. The optional special key 'connection' is
 # used to name the default connection, to use when no --connection parameter is


### PR DESCRIPTION
Some bugzilla installations demand these two parameters explicitly
 given when submitting bugs.

I cannot make use of my buzilla installation (cannot submit bugs) if these parameters aren't set.
I've reworked them so that they can be set on a connection basis via config file or given directly
to 'post' via arguments or be left alone.
