### PR TITLE
Allow the name of the 'bugz' binary to choose the connection used

### DIFF
--- a/bin/bugz
+++ b/bin/bugz
@@ -28,12 +28,15 @@ from bugz.argparsers import make_parser
 from bugz.cli import BugzError, PrettyBugz
 from bugz.configfile import get_config
 
+def program_name():
+    return os.path.basename(sys.argv[0])
+
 def main():
 	parser = make_parser()
 
 	# parse options
 	args = parser.parse_args()
-	get_config(args)
+	get_config(program_name(), args)
 	if getattr(args, 'columns') is None:
 		setattr(args, 'columns', 0)
 

--- a/bugz/configfile.py
+++ b/bugz/configfile.py
@@ -30,7 +30,7 @@ def fill_config(args, parser, section):
 	fill_config_option(args, parser, parser.get, section, 'encoding')
 	fill_config_option(args, parser, parser.getboolean, section, 'quiet')
 
-def get_config(args):
+def get_config(exe_name, args):
 	config_file = getattr(args, 'config_file')
 	if config_file is None:
 			config_file = DEFAULT_CONFIG_FILE
@@ -60,7 +60,14 @@ def get_config(args):
 	if "default" in sections:
 		fill_config(args, parser, "default")
 	if section is None:
-		section = config_option(parser, parser.get, "default", "connection")
+		# 'bugz-alias' handling
+		for i in sections:
+			bugz_alias = config_option(parser, parser.get, i, "bugz-alias")
+			if exe_name == bugz_alias:
+				section = i
+				break
+		else:
+			section = config_option(parser, parser.get, "default", "connection")
 
 	# parse a specific section
 	if section in sections:

--- a/bugzrc.example
+++ b/bugzrc.example
@@ -49,6 +49,15 @@
 #
 # quiet: True
 #
+# A "bugz alias" that allows the name of the 'bugz' binary to determine
+# which connection to use.
+# E.g. suppose you have a [gnome] section for http://bugzilla.gnome.org,
+# Create a symblink to the 'bugz' binary named 'gnomebz'.
+# Add "bugz-alias: gnomebz" to the [gnome] section then
+# invoking "gnomebz" would work like "bugz --connection gnome".
+# 
+# bugz-alias: gnomebz
+#
 # The special section named 'default' may also be used. Other sections will
 # override any values specified here. The optional special key 'connection' is
 # used to name the default connection, to use when no --connection parameter is


### PR DESCRIPTION
The goail is to allow a user to create multiple symlinks to the 'bugz'
binary e.g. 'gnomebz', 'kdebz' each corresponding to a connection.

E.g.
Bugzrc:

[gnome]
bugz-alias: gnomebz
...
[redhat]
bugz-alias: rhbz

Command line usage:

$ gnomebz ... # works like "bugz --connection gnome ..."
$ rhbz ...    # works like "bugz --connection redhat ..."

Inspired by busybox style "multicall binaries".
