### PR TITLE
Align bug status in search result for better readabilty

### DIFF
--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -666,7 +666,7 @@ class PrettyBugz:
 			desc = bug['summary']
 			line = '%s' % (bugid)
 			if show_status:
-				line = '%s %s' % (line, status)
+				line = '%s %-12s' % (line, status)
 			line = '%s %-20s' % (line, assignee)
 			line = '%s %s' % (line, desc)
 


### PR DESCRIPTION
Aligned the bug status to 12 chars to avoid different alignments in the list due to different bug status name length.
