### PR TITLE
Print all fields of a bug object

### DIFF
--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -706,6 +706,15 @@ class PrettyBugz:
 				continue
 			print '%-12s: %s' % (name, value)
 
+                # Other fields handled manually here are:
+                extra_fields = {
+                        'keywords',
+                        'cc',
+                        'depends_on',
+                        'blocks',
+                        'id',
+               }
+
 		# print keywords
 		k = ', '.join(bug['keywords'])
 		if k:
@@ -731,6 +740,17 @@ class PrettyBugz:
 		bug_attachments = self.bzcall(self.bz.Bug.attachments, {'ids':[bug['id']]})
 		bug_attachments = bug_attachments['bugs']['%s' % bug['id']]
 		print '%-12s: %d' % ('Attachments', len(bug_attachments))
+
+                # print all rest fields with prefix @.
+                for field in set(bug.keys()) - set((f for f in FIELDS + MORE_FIELDS)) - extra_fields:
+                        try:
+                                value = bug[field]
+                                if value is None or value == '':
+						continue
+                        except AttributeError:
+                                continue
+                        print '@%-11s: %s' % (field, value)
+
 		print
 
 		if show_attachments:


### PR DESCRIPTION
showbuginfo handles major fields of bug object.  However, there is a
case that more fields are defined in a bug object. Fields not printed
in current version of bugz may be privately extended things. This
patch prints these privately extended fields with prefix `@'.

Signed-off-by: Masatake YAMATO yamato@redhat.com
