### PR TITLE
bugz/cli.py: Use a shell-enabled subprocess for the passwordcmd

### DIFF
--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -177,9 +177,10 @@ class PrettyBugz:
 				log_info('No password given.')
 				self.password = getpass.getpass()
 			else:
-				process = subprocess.Popen(self.passwordcmd.split(), shell=False,
+				process = subprocess.Popen(self.passwordcmd, shell=True,
 					stdout=subprocess.PIPE)
 				self.password, _ = process.communicate()
+				self.password = self.password.split('\n')[0]
 
 		# perform login
 		params = {}


### PR DESCRIPTION
This allows correct handling of quoting and pipes in the command, as currently
something like `gpg2 --decrypt "my bugzilla credentials.gpg" | head -n1`
utterly fails.

For convenience, only the first line of output is kept as password (assumption:
passwords don't contain newlines; this would save the call to head in the
example above).
