### PR TITLE
bugz/cli.py: update passwordcmd processing for Python 3

### DIFF
--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -187,7 +187,7 @@ class PrettyBugz:
 				process = subprocess.Popen(self.passwordcmd, shell=True,
 					stdout=subprocess.PIPE)
 				self.password, _ = process.communicate()
-				self.password = self.password.split('\n')[0]
+				self.password = self.password.splitlines()[0]
 
 		# perform login
 		params = {}


### PR DESCRIPTION
Python3's `Popen.communicate()` returns bytes instead of a string, thus
`.split('\n')` throws an error: the argument should be bytes (`.split(b'\n')`),
not a string.
Instead, rely on `bytes.splitlines()` which is more generic and has the added
advantage that it doesn't require any arguments.

(Note: I only replaced `split('\n')` with `splitlines()` in the passwordcmd
handling code, but it might be worth it to apply this replacement everywhere
where `split('\n')` is used, as it's usually what's really intended and it
deals correctly with weird newline sequences.)
