### PR TITLE
Fix many style and format warnings from the flake8 tool.

### DIFF
--- a/bugz/argparsers.py
+++ b/bugz/argparsers.py
@@ -1,289 +1,300 @@
 from bugz import __version__
 from bugz.cli import PrettyBugz
 
+
 def make_attach_parser(subparsers):
 	attach_parser = subparsers.add_parser('attach',
-		help = 'attach file to a bug')
+		help='attach file to a bug')
 	attach_parser.add_argument('bugid',
-		help = 'the ID of the bug where the file should be attached')
+		help='the ID of the bug where the file should be attached')
 	attach_parser.add_argument('filename',
-		help = 'the name of the file to attach')
+		help='the name of the file to attach')
 	attach_parser.add_argument('-c', '--content-type',
-		help = 'mimetype of the file e.g. text/plain (default: auto-detect)')
+		help='mimetype of the file e.g. text/plain (default: auto-detect)')
 	attach_parser.add_argument('-d', '--description',
-		help = 'a long description of the attachment',
-		dest = 'comment')
+		help='a long description of the attachment',
+		dest='comment')
 	attach_parser.add_argument('-p', '--patch',
-		action = 'store_true',
-		help = 'attachment is a patch',
-		dest = 'is_patch')
+		action='store_true',
+		help='attachment is a patch',
+		dest='is_patch')
 	attach_parser.add_argument('-t', '--title',
-		help = 'a short description of the attachment (default: filename).',
-		dest = 'summary')
-	attach_parser.set_defaults(func = PrettyBugz.attach)
+		help='a short description of the attachment (default: filename).',
+		dest='summary')
+	attach_parser.set_defaults(func=PrettyBugz.attach)
+
 
 def make_attachment_parser(subparsers):
 	attachment_parser = subparsers.add_parser('attachment',
-		help = 'get an attachment from bugzilla')
+		help='get an attachment from bugzilla')
 	attachment_parser.add_argument('attachid',
-		help = 'the ID of the attachment')
+		help='the ID of the attachment')
 	attachment_parser.add_argument('-v', '--view',
 		action="store_true",
-		help = 'print attachment rather than save')
-	attachment_parser.set_defaults(func = PrettyBugz.attachment)
+		help='print attachment rather than save')
+	attachment_parser.set_defaults(func=PrettyBugz.attachment)
+
 
 def make_get_parser(subparsers):
 	get_parser = subparsers.add_parser('get',
-		help = 'get a bug from bugzilla')
+		help='get a bug from bugzilla')
 	get_parser.add_argument('bugid',
-		help = 'the ID of the bug to retrieve.')
+		help='the ID of the bug to retrieve.')
 	get_parser.add_argument("-a", "--no-attachments",
 		action="store_true",
-		help = 'do not show attachments')
+		help='do not show attachments')
 	get_parser.add_argument("-n", "--no-comments",
 		action="store_true",
-		help = 'do not show comments')
-	get_parser.set_defaults(func = PrettyBugz.get)
+		help='do not show comments')
+	get_parser.set_defaults(func=PrettyBugz.get)
+
 
 def make_login_parser(subparsers):
 	login_parser = subparsers.add_parser('login',
-		help = 'log into bugzilla')
-	login_parser.set_defaults(func = PrettyBugz.login)
+		help='log into bugzilla')
+	login_parser.set_defaults(func=PrettyBugz.login)
+
 
 def make_logout_parser(subparsers):
 	logout_parser = subparsers.add_parser('logout',
-		help = 'log out of bugzilla')
-	logout_parser.set_defaults(func = PrettyBugz.logout)
+		help='log out of bugzilla')
+	logout_parser.set_defaults(func=PrettyBugz.logout)
+
 
 def make_modify_parser(subparsers):
 	modify_parser = subparsers.add_parser('modify',
-		help = 'modify a bug (eg. post a comment)')
+		help='modify a bug (eg. post a comment)')
 	modify_parser.add_argument('bugid',
-		help = 'the ID of the bug to modify')
+		help='the ID of the bug to modify')
 	modify_parser.add_argument('--alias',
-		help = 'change the alias for this bug')
+		help='change the alias for this bug')
 	modify_parser.add_argument('-a', '--assigned-to',
-		help = 'change assignee for this bug')
+		help='change assignee for this bug')
 	modify_parser.add_argument('--add-blocked',
-		action = 'append',
-		help = 'add a bug to the blocked list',
-		dest = 'blocks_add')
+		action='append',
+		help='add a bug to the blocked list',
+		dest='blocks_add')
 	modify_parser.add_argument('--remove-blocked',
-		action = 'append',
-		help = 'remove a bug from the blocked list',
-		dest = 'blocks_remove')
+		action='append',
+		help='remove a bug from the blocked list',
+		dest='blocks_remove')
 	modify_parser.add_argument('--add-dependson',
-		action = 'append',
-		help = 'add a bug to the depends list',
-		dest = 'depends_on_add')
+		action='append',
+		help='add a bug to the depends list',
+		dest='depends_on_add')
 	modify_parser.add_argument('--remove-dependson',
-		action = 'append',
-		help = 'remove a bug from the depends list',
-		dest = 'depends_on_remove')
+		action='append',
+		help='remove a bug from the depends list',
+		dest='depends_on_remove')
 	modify_parser.add_argument('--add-cc',
-		action = 'append',
-		help = 'add an email to the CC list',
-		dest = 'cc_add')
+		action='append',
+		help='add an email to the CC list',
+		dest='cc_add')
 	modify_parser.add_argument('--remove-cc',
-		action = 'append',
-		help = 'remove an email from the CC list',
-		dest = 'cc_remove')
+		action='append',
+		help='remove an email from the CC list',
+		dest='cc_remove')
 	modify_parser.add_argument('-c', '--comment',
-		help = 'add comment from command line')
+		help='add comment from command line')
 	modify_parser.add_argument('-C', '--comment-editor',
 		action='store_true',
-		help = 'add comment via default editor')
+		help='add comment via default editor')
 	modify_parser.add_argument('-F', '--comment-from',
-		help = 'add comment from file.  If -C is also specified, the editor will be opened with this file as its contents.')
+		help='add comment from file.  If -C is also specified,'
+		' the editor will be opened with this file'
+		' as its contents.')
 	modify_parser.add_argument('--component',
-		help = 'change the component for this bug')
+		help='change the component for this bug')
 	modify_parser.add_argument('-d', '--duplicate',
-		type = int,
-		help = 'this bug is a duplicate',
-		dest = 'dupe_of')
+		type=int,
+		help='this bug is a duplicate',
+		dest='dupe_of')
 	modify_parser.add_argument('--add-group',
-		action = 'append',
-		help = 'add a group to this bug',
-		dest = 'groups_add')
+		action='append',
+		help='add a group to this bug',
+		dest='groups_add')
 	modify_parser.add_argument('--remove-group',
-		action = 'append',
-		help = 'remove agroup from this bug',
-		dest = 'groups_remove')
+		action='append',
+		help='remove agroup from this bug',
+		dest='groups_remove')
 	modify_parser.add_argument('--set-keywords',
-		action = 'append',
-		help = 'set bug keywords',
-		dest = 'keywords_set')
+		action='append',
+		help='set bug keywords',
+		dest='keywords_set')
 	modify_parser.add_argument('--op-sys',
-		help = 'change the operating system for this bug')
+		help='change the operating system for this bug')
 	modify_parser.add_argument('--platform',
-		help = 'change the hardware platform for this bug')
+		help='change the hardware platform for this bug')
 	modify_parser.add_argument('--priority',
-		help = 'change the priority for this bug')
+		help='change the priority for this bug')
 	modify_parser.add_argument('--product',
-		help = 'change the product for this bug')
+		help='change the product for this bug')
 	modify_parser.add_argument('-r', '--resolution',
-		help = 'set new resolution (only if status = RESOLVED)')
+		help='set new resolution (only if status = RESOLVED)')
 	modify_parser.add_argument('--add-see-also',
-		action = 'append',
-		help = 'add a "see also" URL to this bug',
-		dest = 'see_also_add')
+		action='append',
+		help='add a "see also" URL to this bug',
+		dest='see_also_add')
 	modify_parser.add_argument('--remove-see-also',
-		action = 'append',
-		help = 'remove a"see also" URL from this bug',
-		dest = 'see_also_remove')
+		action='append',
+		help='remove a"see also" URL from this bug',
+		dest='see_also_remove')
 	modify_parser.add_argument('-S', '--severity',
-		help = 'set severity for this bug')
+		help='set severity for this bug')
 	modify_parser.add_argument('-s', '--status',
-		help = 'set new status of bug (eg. RESOLVED)')
+		help='set new status of bug (eg. RESOLVED)')
 	modify_parser.add_argument('-t', '--title',
-		help = 'set title of bug',
-		dest = 'summary')
+		help='set title of bug',
+		dest='summary')
 	modify_parser.add_argument('-U', '--url',
-		help = 'set URL field of bug')
+		help='set URL field of bug')
 	modify_parser.add_argument('-v', '--version',
-		help = 'set the version for this bug'),
+		help='set the version for this bug'),
 	modify_parser.add_argument('-w', '--whiteboard',
-		help = 'set Status whiteboard'),
+		help='set Status whiteboard'),
 	modify_parser.add_argument('--fixed',
 		action='store_true',
-		help = 'mark bug as RESOLVED, FIXED')
+		help='mark bug as RESOLVED, FIXED')
 	modify_parser.add_argument('--invalid',
 		action='store_true',
-		help = 'mark bug as RESOLVED, INVALID')
-	modify_parser.set_defaults(func = PrettyBugz.modify)
+		help='mark bug as RESOLVED, INVALID')
+	modify_parser.set_defaults(func=PrettyBugz.modify)
+
 
 def make_post_parser(subparsers):
 	post_parser = subparsers.add_parser('post',
-		help = 'post a new bug into bugzilla')
+		help='post a new bug into bugzilla')
 	post_parser.add_argument('--product',
-		help = 'product')
+		help='product')
 	post_parser.add_argument('--component',
-		help = 'component')
+		help='component')
 	post_parser.add_argument('--version',
-		help = 'version of the product')
+		help='version of the product')
 	post_parser.add_argument('-t', '--title',
-		help = 'title of bug',
-		dest = 'summary')
+		help='title of bug',
+		dest='summary')
 	post_parser.add_argument('-d', '--description',
-		help = 'description of the bug')
+		help='description of the bug')
 	post_parser.add_argument('--op-sys',
-		help = 'set the operating system')
+		help='set the operating system')
 	post_parser.add_argument('--platform',
-		help = 'set the hardware platform')
+		help='set the hardware platform')
 	post_parser.add_argument('--priority',
-		help = 'set priority for the new bug')
+		help='set priority for the new bug')
 	post_parser.add_argument('-S', '--severity',
-		help = 'set the severity for the new bug')
+		help='set the severity for the new bug')
 	post_parser.add_argument('--alias',
-		help = 'set the alias for this bug')
+		help='set the alias for this bug')
 	post_parser.add_argument('-a', '--assigned-to',
-		help = 'assign bug to someone other than the default assignee')
+		help='assign bug to someone other than the default assignee')
 	post_parser.add_argument('--cc',
-		help = 'add a list of emails to CC list')
+		help='add a list of emails to CC list')
 	post_parser.add_argument('-U', '--url',
-		help = 'set URL field of bug')
-	post_parser.add_argument('-F' , '--description-from',
-		help = 'description from contents of file')
+		help='set URL field of bug')
+	post_parser.add_argument('-F', '--description-from',
+		help='description from contents of file')
 	post_parser.add_argument('--append-command',
-		help = 'append the output of a command to the description')
+		help='append the output of a command to the description')
 	post_parser.add_argument('--batch',
 		action="store_true",
-		help = 'do not prompt for any values')
+		help='do not prompt for any values')
 	post_parser.add_argument('--default-confirm',
-		choices = ['y','Y','n','N'],
-		default = 'y',
-		help = 'default answer to confirmation question')
-	post_parser.set_defaults(func = PrettyBugz.post)
+		choices=['y', 'Y', 'n', 'N'],
+		default='y',
+		help='default answer to confirmation question')
+	post_parser.set_defaults(func=PrettyBugz.post)
+
 
 def make_search_parser(subparsers):
 	search_parser = subparsers.add_parser('search',
-		help = 'search for bugs in bugzilla')
+		help='search for bugs in bugzilla')
 	search_parser.add_argument('terms',
 		nargs='*',
-		help = 'strings to search for in title and/or body')
+		help='strings to search for in title and/or body')
 	search_parser.add_argument('--alias',
 		help='The unique alias for this bug')
 	search_parser.add_argument('-a', '--assigned-to',
-		help = 'email the bug is assigned to')
+		help='email the bug is assigned to')
 	search_parser.add_argument('-C', '--component',
 		action='append',
-		help = 'restrict by component (1 or more)')
+		help='restrict by component (1 or more)')
 	search_parser.add_argument('-r', '--creator',
-		help = 'email of the person who created the bug')
+		help='email of the person who created the bug')
 	search_parser.add_argument('-l', '--limit',
-		type = int,
+		type=int,
 		help='Limit the number of records returned in a search')
 	search_parser.add_argument('--offset',
-		type = int,
+		type=int,
 		help='Set the start position for a search')
 	search_parser.add_argument('--op-sys',
 		action='append',
-		help = 'restrict by Operating System (one or more)')
+		help='restrict by Operating System (one or more)')
 	search_parser.add_argument('--platform',
 		action='append',
-		help = 'restrict by platform (one or more)')
+		help='restrict by platform (one or more)')
 	search_parser.add_argument('--priority',
 		action='append',
-		help = 'restrict by priority (one or more)')
+		help='restrict by priority (one or more)')
 	search_parser.add_argument('--product',
 		action='append',
-		help = 'restrict by product (one or more)')
+		help='restrict by product (one or more)')
 	search_parser.add_argument('--resolution',
-		help = 'restrict by resolution')
+		help='restrict by resolution')
 	search_parser.add_argument('--severity',
 		action='append',
-		help = 'restrict by severity (one or more)')
+		help='restrict by severity (one or more)')
 	search_parser.add_argument('-s', '--status',
 		action='append',
-		help = 'restrict by status (one or more, use all for all statuses)')
+		help='restrict by status (one or more, use all for all statuses)')
 	search_parser.add_argument('-v', '--version',
 		action='append',
-		help = 'restrict by version (one or more)')
+		help='restrict by version (one or more)')
 	search_parser.add_argument('-w', '--whiteboard',
-		help = 'status whiteboard')
+		help='status whiteboard')
 	search_parser.add_argument('--show-status',
-		action = 'store_true',
+		action='store_true',
 		help='show status of bugs')
 	search_parser.add_argument('--show-priority',
-		action = 'store_true',
+		action='store_true',
 		help='show priority of bugs')
 	search_parser.add_argument('--show-severity',
-		action = 'store_true',
+		action='store_true',
 		help='show severity of bugs')
-	search_parser.set_defaults(func = PrettyBugz.search)
+	search_parser.set_defaults(func=PrettyBugz.search)
+
 
 def make_parser(parser):
 	parser.add_argument('--config-file',
-		help = 'read an alternate configuration file')
+		help='read an alternate configuration file')
 	parser.add_argument('--connection',
-		help = 'use [connection] section of your configuration file')
+		help='use [connection] section of your configuration file')
 	parser.add_argument('-b', '--base',
-		help = 'base URL of Bugzilla')
+		help='base URL of Bugzilla')
 	parser.add_argument('-u', '--user',
-		help = 'username for commands requiring authentication')
+		help='username for commands requiring authentication')
 	parser.add_argument('-p', '--password',
-		help = 'password for commands requiring authentication')
+		help='password for commands requiring authentication')
 	parser.add_argument('--passwordcmd',
-		help = 'password command to evaluate for commands requiring authentication')
+		help='password command to evaluate for commands requiring authentication')
 	parser.add_argument('-q', '--quiet',
 		action='store_true',
-		help = 'quiet mode')
+		help='quiet mode')
 	parser.add_argument('-d', '--debug',
 		type=int,
-		help = 'debug level (from 0 to 3)')
+		help='debug level (from 0 to 3)')
 	parser.add_argument('--columns',
-		type = int,
-		help = 'maximum number of columns output should use')
+		type=int,
+		help='maximum number of columns output should use')
 	parser.add_argument('--encoding',
-		help = 'output encoding (default: utf-8) (deprecated)')
+		help='output encoding (default: utf-8) (deprecated)')
 	parser.add_argument('--skip-auth',
 		action='store_true',
-		help = 'skip Authentication.')
+		help='skip Authentication.')
 	parser.add_argument('--version',
 		action='version',
 		help='show program version and exit',
 		version='%(prog)s ' + __version__)
-	subparsers = parser.add_subparsers(help = 'help for sub-commands')
+	subparsers = parser.add_subparsers(help='help for sub-commands')
 	make_attach_parser(subparsers)
 	make_attachment_parser(subparsers)
 	make_get_parser(subparsers)

--- a/bugz/bugzilla.py
+++ b/bugz/bugzilla.py
@@ -5,8 +5,11 @@
 # http://www.bugzilla.org/docs/4.2/en/html/api/Bugzilla/WebService.html
 
 import http.cookiejar
-import urllib.request, urllib.parse, urllib.error
+import urllib.request
+import urllib.parse
+import urllib.error
 import xmlrpc.client
+
 
 class RequestTransport(xmlrpc.client.Transport):
 	def __init__(self, uri, cookiejar=None, use_datetime=0):
@@ -49,7 +52,9 @@ class RequestTransport(xmlrpc.client.Transport):
 			return self.parse_response(resp)
 
 		resp.close()
-		raise xmlrpc.client.ProtocolError(self.uri, resp.status, resp.reason, resp.msg)
+		raise xmlrpc.client.ProtocolError(self.uri,
+				resp.status, resp.reason, resp.msg)
+
 
 class BugzillaProxy(xmlrpc.client.ServerProxy):
 	def __init__(self, uri, encoding=None, verbose=0, allow_none=0,

--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -23,6 +23,7 @@ from bugz.utils import block_edit, get_content_type
 DEFAULT_COOKIE_FILE = '.bugz_cookie'
 DEFAULT_TOKEN_FILE = '.bugz_token'
 
+
 class PrettyBugz:
 	def __init__(self, conn):
 		cookie_file = os.path.join(os.environ['HOME'], DEFAULT_COOKIE_FILE)
@@ -112,7 +113,8 @@ class PrettyBugz:
 			raise BugzError("Failed to logout: " + fault.faultString)
 
 	def search(self, conn):
-		"""Performs a search on the bugzilla database with the keywords given on the title (or the body if specified).
+		"""Performs a search on the bugzilla database with
+the keywords given on the title (or the body if specified).
 		"""
 		valid_keys = ['alias', 'assigned_to', 'component', 'creator',
 			'limit', 'offset', 'op_sys', 'platform',
@@ -164,9 +166,9 @@ class PrettyBugz:
 		""" Fetch bug details given the bug id """
 		log_info('Getting bug %s ..' % conn.bugid)
 		try:
-			result = self.call_bz(self.bz.Bug.get, {'ids':[conn.bugid]})
+			result = self.call_bz(self.bz.Bug.get, {'ids': [conn.bugid]})
 		except xmlrpc.client.Fault as fault:
-			raise BugzError("Can't get bug #" + str(conn.bugid) + ": " \
+			raise BugzError("Can't get bug #" + str(conn.bugid) + ": "
 					+ fault.faultString)
 
 		for bug in result['bugs']:
@@ -181,7 +183,7 @@ class PrettyBugz:
 					if conn.description_from == '-':
 						conn.description = sys.stdin.read()
 					else:
-						conn.description = open( conn.description_from, 'r').read()
+						conn.description = open(conn.description_from, 'r').read()
 			except IOError as e:
 				raise BugzError('Unable to read from file: %s: %s' %
 					(conn.description_from, e))
@@ -256,7 +258,7 @@ class PrettyBugz:
 
 			# check for default priority
 			if not hasattr(conn, 'priority'):
-				priority_msg ='Enter priority (eg. Normal) (optional): '
+				priority_msg = 'Enter priority (eg. Normal) (optional): '
 				line = input(priority_msg)
 				if len(line):
 					conn.priority = line
@@ -265,7 +267,7 @@ class PrettyBugz:
 
 			# check for default severity
 			if not hasattr(conn, 'severity'):
-				severity_msg ='Enter severity (eg. normal) (optional): '
+				severity_msg = 'Enter severity (eg. normal) (optional): '
 				line = input(severity_msg)
 				if len(line):
 					conn.severity = line
@@ -274,7 +276,7 @@ class PrettyBugz:
 
 			# check for default alias
 			if not hasattr(conn, 'alias'):
-				alias_msg ='Enter an alias for this bug (optional): '
+				alias_msg = 'Enter an alias for this bug (optional): '
 				line = input(alias_msg)
 				if len(line):
 					conn.alias = line
@@ -283,7 +285,7 @@ class PrettyBugz:
 
 			# check for default assignee
 			if not hasattr(conn, 'assigned_to'):
-				assign_msg ='Enter assignee (eg. liquidx@gentoo.org) (optional): '
+				assign_msg = 'Enter assignee (eg. liquidx@gentoo.org) (optional): '
 				line = input(assign_msg)
 				if len(line):
 					conn.assigned_to = line
@@ -315,7 +317,8 @@ class PrettyBugz:
 			# fixme: milestone
 
 			if not hasattr(conn, 'append_command'):
-				line = input('Append the output of the following command (leave blank for none): ')
+				line = input('Append the output of the'
+				' following command (leave blank for none): ')
 				if len(line):
 					conn.append_command = line
 			else:
@@ -342,7 +345,7 @@ class PrettyBugz:
 		# print submission confirmation
 		print('-' * (conn.columns - 1))
 		print('%-12s: %s' % ('Product', conn.product))
-		print('%-12s: %s' %('Component', conn.component))
+		print('%-12s: %s' % ('Component', conn.component))
 		print('%-12s: %s' % ('Title', conn.summary))
 		print('%-12s: %s' % ('Version', conn.version))
 		print('%-12s: %s' % ('Description', conn.description))
@@ -368,7 +371,7 @@ class PrettyBugz:
 		print('-' * (conn.columns - 1))
 
 		if not getattr(conn, 'batch', None):
-			if conn.default_confirm in ['Y','y']:
+			if conn.default_confirm in ['Y', 'y']:
 				confirm = input('Confirm bug submission (Y/n)? ')
 			else:
 				confirm = input('Confirm bug submission (y/N)? ')
@@ -378,7 +381,7 @@ class PrettyBugz:
 				log_info('Submission aborted')
 				return
 
-		params={}
+		params = {}
 		params['product'] = conn.product
 		params['component'] = conn.component
 		params['version'] = conn.version
@@ -414,7 +417,7 @@ class PrettyBugz:
 				else:
 					conn.comment = open(conn.comment_from, 'r').read()
 			except IOError as e:
-				raise BugzError('unable to read file: %s: %s' % \
+				raise BugzError('unable to read file: %s: %s' %
 					(conn.comment_from, e))
 
 		if conn.comment_editor:
@@ -521,8 +524,8 @@ class PrettyBugz:
 			else:
 				log_info('Modified the following fields in bug %s' % bug['id'])
 				for key in changes:
-					log_info('%-12s: removed %s' %(key, changes[key]['removed']))
-					log_info('%-12s: added %s' %(key, changes[key]['added']))
+					log_info('%-12s: removed %s' % (key, changes[key]['removed']))
+					log_info('%-12s: added %s' % (key, changes[key]['added']))
 
 	def attachment(self, conn):
 		""" Download or view an attachment given the id."""
@@ -534,7 +537,7 @@ class PrettyBugz:
 		result = result['attachments'][conn.attachid]
 		view = getattr(conn, 'view', False)
 
-		action = {True:'Viewing', False:'Saving'}
+		action = {True: 'Viewing', False: 'Saving'}
 		log_info('%s attachment: "%s"' %
 			(action[view], result['file_name']))
 		safe_filename = os.path.basename(re.sub(r'\.\.', '',
@@ -581,10 +584,10 @@ class PrettyBugz:
 		params['file_name'] = os.path.basename(filename)
 		params['summary'] = summary
 		if not is_patch:
-			params['content_type'] = content_type;
+			params['content_type'] = content_type
 		params['comment'] = comment
 		params['is_patch'] = is_patch
-		result =  self.call_bz(self.bz.Bug.add_attachment, params)
+		result = self.call_bz(self.bz.Bug.add_attachment, params)
 		log_info("'%s' has been attached to bug %s" % (filename, bugid))
 
 	def list_bugs(self, buglist, conn):
@@ -648,7 +651,7 @@ class PrettyBugz:
 			value = bug[field]
 			if field in ['cc', 'see_also']:
 				for x in value:
-					print('%-12s: %s' %  (desc, x))
+					print('%-12s: %s' % (desc, x))
 			elif isinstance(value, list):
 				s = ', '.join(["%s" % x for x in value])
 				if s:
@@ -657,7 +660,8 @@ class PrettyBugz:
 				print('%-12s: %s' % (desc, value))
 
 		if not getattr(conn, 'no_attachments', False):
-			bug_attachments = self.call_bz(self.bz.Bug.attachments, {'ids':[bug['id']]})
+			bug_attachments = self.call_bz(self.bz.Bug.attachments,
+					{'ids': [bug['id']]})
 			bug_attachments = bug_attachments['bugs']['%s' % bug['id']]
 			print('%-12s: %d' % ('Attachments', len(bug_attachments)))
 			print()
@@ -668,14 +672,14 @@ class PrettyBugz:
 				print('[Attachment] [%s] [%s]' % (aid, desc))
 
 		if not getattr(conn, 'no_comments', False):
-			bug_comments = self.call_bz(self.bz.Bug.comments, {'ids':[bug['id']]})
+			bug_comments = self.call_bz(self.bz.Bug.comments, {'ids': [bug['id']]})
 			bug_comments = bug_comments['bugs']['%s' % bug['id']]['comments']
 			print('%-12s: %d' % ('Comments', len(bug_comments)))
 			print()
 			i = 0
-			wrapper = textwrap.TextWrapper(width = conn.columns,
-				break_long_words = False,
-				break_on_hyphens = False)
+			wrapper = textwrap.TextWrapper(width=conn.columns,
+				break_long_words=False,
+				break_on_hyphens=False)
 			for comment in bug_comments:
 				who = comment['creator']
 				when = comment['time']

--- a/bugz/configfile.py
+++ b/bugz/configfile.py
@@ -5,6 +5,7 @@ import sys
 
 from bugz.log import log_error
 
+
 def read_config(parser, ConfigFiles):
 	try:
 		parser.read(ConfigFiles)
@@ -25,8 +26,9 @@ def read_config(parser, ConfigFiles):
 		log_error(e)
 		sys.exit(1)
 
+
 def get_config(parser, UserConfig=None):
-	DefaultConfigs = sorted(glob.glob(sys.prefix+'/share/pybugz.d/*.conf'))
+	DefaultConfigs = sorted(glob.glob(sys.prefix + '/share/pybugz.d/*.conf'))
 	SystemConfigs = sorted(glob.glob('/etc/pybugz.d/*.conf'))
 	if UserConfig is not None:
 		UserConfig = os.path.expanduser(UserConfig)
@@ -36,16 +38,17 @@ def get_config(parser, UserConfig=None):
 	read_config(parser, SystemConfigs)
 	read_config(parser, UserConfig)
 
+
 def get_config_option(get, section, option):
 	try:
 		value = get(section, option)
 		if value == '':
-			log_error("Error: "+option+" is not set")
+			log_error("Error: " + option + " is not set")
 			sys.exit(1)
 
 		return value
 
 	except ValueError as e:
-		log_error("Error: option "+option+
-				" is not in the right format: "+str(e))
+		log_error("Error: option " + option +
+				" is not in the right format: " + str(e))
 		sys.exit(1)

--- a/bugz/connection.py
+++ b/bugz/connection.py
@@ -5,6 +5,7 @@ from bugz.log import log_debug, log_error, log_info
 from bugz.log import log_setDebugLevel, log_setQuiet
 from bugz.utils import terminal_width
 
+
 class Connection:
 	def __init__(self, args, config):
 		for attr, value in args.__dict__.items():
@@ -77,5 +78,5 @@ class Connection:
 		log_info("Using [{0}] ({1})".format(self.connection, self.base))
 
 		log_debug('Connection debug dump:', 3)
-		for attr,value in self.__dict__.items():
+		for attr, value in self.__dict__.items():
 			log_debug('{0}, {1}'.format(attr, getattr(self, attr)), 3)

--- a/bugz/errhandling.py
+++ b/bugz/errhandling.py
@@ -2,5 +2,6 @@
 # Bugz specific exceptions
 #
 
+
 class BugzError(Exception):
 	pass

--- a/bugz/log.py
+++ b/bugz/log.py
@@ -5,31 +5,33 @@ debugLevel = 0
 quiet = False
 
 LogSettings = {
-	'W' : {
-		'sym' : '!',
-		'word' : 'Warn',
+	'W': {
+		'sym': '!',
+		'word': 'Warn',
 	},
-	'E' : {
-		'sym' : '#',
-		'word' : 'Error',
+	'E': {
+		'sym': '#',
+		'word': 'Error',
 	},
-	'D' : {
-		'sym' : '~',
-		'word' : 'Dbg',
+	'D': {
+		'sym': '~',
+		'word': 'Dbg',
 	},
-	'I' : {
-		'sym' : '*',
-		'word' : 'Info',
+	'I': {
+		'sym': '*',
+		'word': 'Info',
 	},
-	'!' : {
-		'sym' : '!',
-		'word' : 'UNKNWN',
+	'!': {
+		'sym': '!',
+		'word': 'UNKNWN',
 	},
 }
+
 
 def log_setQuiet(newQuiet):
 	global quiet
 	quiet = newQuiet
+
 
 def log_setDebugLevel(newLevel):
 	global debugLevel
@@ -41,28 +43,33 @@ def log_setDebugLevel(newLevel):
 	else:
 		debugLevel = newLevel
 
+
 def formatOut(msg, id='!'):
 	lines = str(msg).split('\n')
 	start = True
-	sym=LogSettings[id]['sym']
-	word=LogSettings[id]['word'] + ":"
+	sym = LogSettings[id]['sym']
+	word = LogSettings[id]['word'] + ":"
 
 	for line in lines:
 		print(' ' + sym + ' ' + line)
+
 
 def log_error(string):
 	formatOut(string, 'E')
 	return
 
+
 def log_warn(string):
 	formatOut(string, 'W')
 	return
+
 
 def log_info(string):
 	# debug implies info
 	if not quiet or debugLevel:
 		formatOut(string, 'I')
 	return
+
 
 def log_debug(string, msgLevel=1):
 	if debugLevel >= msgLevel:

--- a/bugz/utils.py
+++ b/bugz/utils.py
@@ -13,8 +13,7 @@ from bugz.bugzilla import BugzillaProxy
 from bugz.errhandling import BugzError
 from bugz.log import log_info
 
-BUGZ_COMMENT_TEMPLATE = \
-"""
+BUGZ_COMMENT_TEMPLATE = """
 BUGZ: ---------------------------------------------------
 %s
 BUGZ: Any line beginning with 'BUGZ:' will be ignored.
@@ -27,8 +26,10 @@ DEFAULT_NUM_COLS = 80
 # Auxiliary functions
 #
 
+
 def get_content_type(filename):
 	return mimetypes.guess_type(filename)[0] or 'application/octet-stream'
+
 
 def raw_input_block():
 	""" Allows multiple line input until a Ctrl+D is detected.
@@ -46,13 +47,17 @@ def raw_input_block():
 #
 # This function was lifted from Bazaar 1.9.
 #
+
+
 def terminal_width():
 	"""Return estimated terminal width."""
 	if sys.platform == 'win32':
 		return win32utils.get_console_size()[0]
 	width = DEFAULT_NUM_COLS
 	try:
-		import struct, fcntl, termios
+		import struct
+		import fcntl
+		import termios
 		s = struct.pack('HHHH', 0, 0, 0, 0)
 		x = fcntl.ioctl(1, termios.TIOCGWINSZ, s)
 		width = struct.unpack('HHHH', x)[1]
@@ -68,7 +73,8 @@ def terminal_width():
 
 	return width
 
-def launch_editor(initial_text, comment_from = '',comment_prefix = 'BUGZ:'):
+
+def launch_editor(initial_text, comment_from='', comment_prefix='BUGZ:'):
 	"""Launch an editor with some default text.
 
 	Lifted from Mercurial 0.9.
@@ -94,7 +100,8 @@ def launch_editor(initial_text, comment_from = '',comment_prefix = 'BUGZ:'):
 
 	return ''
 
-def block_edit(comment, comment_from = ''):
+
+def block_edit(comment, comment_from=''):
 	editor = (os.environ.get('BUGZ_EDITOR') or
 			os.environ.get('EDITOR'))
 
@@ -103,7 +110,7 @@ def block_edit(comment, comment_from = ''):
 		new_text = raw_input_block()
 		return new_text
 
-	initial_text = '\n'.join(['BUGZ: %s'%line for line in
+	initial_text = '\n'.join(['BUGZ: %s' % line for line in
 		comment.splitlines()])
 	new_text = launch_editor(BUGZ_COMMENT_TEMPLATE % initial_text, comment_from)
 


### PR DESCRIPTION
This makes us more conformant with PEP 8. Warnings caused by using tabs
instead of spaces have not been fixed.  For now, we can just write a config
file to ignore them.
