### PR TITLE
lbugz: simpler exec

### DIFF
--- a/lbugz
+++ b/lbugz
@@ -11,9 +11,8 @@ This is based on a patch from Mike Frysinger <vapier@gentoo.org>.
 """
 
 import os
-import subprocess
 import sys
- 
+
 args = sys.argv
 path = os.path.normpath(os.path.dirname(os.path.realpath(__file__)))
 pkg = os.path.join(path, 'bugz')
@@ -25,4 +24,4 @@ if os.path.exists(pkg) and os.path.exists(script):
 		os.environ['PYTHONPATH'] = path + ':' + os.environ['PYTHONPATH']
 	else:
 		os.environ['PYTHONPATH'] = path + ':'
-	sys.exit(subprocess.call(args))
+	os.execv(args[0], args)


### PR DESCRIPTION
No need to go through subprocess which does a fork and monitors the child.
Simply exec the target bugz directly.