### PR TITLE
Add FreeBSD Bugzilla support

### DIFF
--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 import textwrap
 import xmlrpc.client
+import urllib.parse
 
 try:
     import readline
@@ -647,7 +648,8 @@ the keywords given on the title (or the body if specified).
         if 'all' not in d['status']:
             params['status'] = d['status']
     elif 'search_statuses' in d:
-                params['status'] = d['search_statuses']
+        params['status'] = [ urllib.parse.unquote(s)
+                             for s in d['search_statuses'] ]
     if 'terms' in d:
         params['summary'] = d['terms']
 

--- a/pybugz.d/freebsd.conf
+++ b/pybugz.d/freebsd.conf
@@ -1,0 +1,3 @@
+[FreeBSD]
+base = https://bugs.freebsd.org/bugzilla/xmlrpc.cgi
+search_statuses = New Open In%%20Progress UNCONFIRMED


### PR DESCRIPTION
https://bugs.freebsd.org/bugzilla/buglist.cgi?quicksearch=bsd.port.mk

vs.

```
$ bugz --skip-auth --connection FreeBSD search bsd.port.mk | sed '/^[0-9]/d'
 * Info: Using [FreeBSD] (https://bugs.freebsd.org/bugzilla/xmlrpc.cgi)
 * Info: Searching for bugs meeting the following criteria:
 * Info:    summary              = ['bsd.port.mk']
 * Info:    status               = ['New', 'Open', 'In Progress', 'UNCONFIRMED']
 * Info: 41 bug(s) found.
```
