### PR TITLE
--unassign flag for modify

### DIFF
--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -418,6 +418,9 @@ def modify(settings):
             raise BugzError('unable to read file: %s: %s' %
                             (settings.comment_from, error))
 
+    if hasattr(settings, 'assigned_to') and hasattr(settings, 'unassign'):
+        raise BugzError('--assigned-to and --unassign cannot be used together')
+
     if hasattr(settings, 'comment_editor'):
         settings.comment = block_edit('Enter comment:')
 
@@ -427,6 +430,8 @@ def modify(settings):
         params['alias'] = settings.alias
     if hasattr(settings, 'assigned_to'):
         params['assigned_to'] = settings.assigned_to
+    if hasattr(settings, 'unassign'):
+        params['reset_assigned_to'] = True
     if hasattr(settings, 'blocks_add'):
         if 'blocks' not in params:
             params['blocks'] = {}

--- a/bugz/cli_argparser.py
+++ b/bugz/cli_argparser.py
@@ -192,6 +192,9 @@ def make_arg_parser():
     modify_parser.add_argument('-t', '--title',
                                dest='summary',
                                help='set title of bug')
+    modify_parser.add_argument('-u', '--unassign',
+                               dest='unassign', action='store_true',
+                               help='Reassign the bug to default owner')
     modify_parser.add_argument('-U', '--url',
                                help='set URL field of bug')
     modify_parser.add_argument('-v', '--version',


### PR DESCRIPTION
Return the bug to the default owner (e.g. when you give up on a bug)