### PR TITLE
--not-status flag

### DIFF
--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -653,9 +653,6 @@ the keywords given on the title (or the body if specified).
     if 'terms' in d:
         params['summary'] = d['terms']
 
-    if not params:
-        raise BugzError('Please give search terms or options.')
-
     log_info('Searching for bugs meeting the following criteria:')
     for key in params:
         log_info('   {0:<20} = {1}'.format(key, params[key]))
@@ -664,6 +661,9 @@ the keywords given on the title (or the body if specified).
         login(settings)
 
     result = settings.call_bz(settings.bz.Bug.search, params)['bugs']
+
+    if hasattr(settings, 'not_status'):
+        result = list(b for b in result if b['status'] not in settings.not_status)
 
     if not len(result):
         log_info('No bugs found.')

--- a/bugz/cli_argparser.py
+++ b/bugz/cli_argparser.py
@@ -294,6 +294,10 @@ def make_arg_parser():
                                action='append',
                                help='restrict by status '
                                '(one or more, use all for all statuses)')
+    search_parser.add_argument('-S', '--not-status',
+                               action='append',
+                               help='exclude by status '
+                               '(one or more, use all for all statuses)')
     search_parser.add_argument('-v', '--version',
                                action='append',
                                help='restrict by version (one or more)')


### PR DESCRIPTION
I commonly want to see anything apart from unconfirmed or resolved bugs.
This is useful this.

I have also (somewhat contentiously) allowed a search without any
keyword specified. This is useful for getting all bugz for
a particularly product or component.

I don't know if we want to insist that *some* constraint is
applied: If people want to list all bugz they should
be probably be free to do so...