### PR TITLE
man: Update the "SEE ALSO" section to include other pybugz man pages

### DIFF
--- a/man/bugz.1
+++ b/man/bugz.1
@@ -32,8 +32,9 @@ will show the help for a specific subcommand.
 .PP
 The home page of this project is http://www.github.com/williamh/pybugz.
 Bugs should be reported to the bug tracker there.
-.\" .SH SEE ALSO
-.\" .PP
+.SH SEE ALSO
+.PP
+\fBpybugz.d\fR(5)
 .SH AUTHOR
 .PP
 The original author is Alastair Tse <alastair@liquidx.net>.

--- a/man/pybugz.d.5
+++ b/man/pybugz.d.5
@@ -134,8 +134,9 @@ space separated list of Bugzilla statuses.
 .PP
 The home page of this project is http://www.github.com/williamh/pybugz.
 Bugs should be reported to the bug tracker there.
-.\" .SH SEE ALSO
-.\" .PP
+.SH SEE ALSO
+.PP
+\fBbugz\fR(1)
 .SH AUTHOR
 .PP
 William Hubbs <w.d.hubbs@gmail.com>


### PR DESCRIPTION
This adds bugz(1) to pybugz.d(5) and vice versa.

This should be pretty trivial. I just could never remeber the pybugz.d man page and thought this would be helpful.