### PR TITLE
Added template support for bug creation

### DIFF
--- a/README
+++ b/README
@@ -90,6 +90,17 @@ or if we find that the bug is invalid, we can close it by using:
 
 $ bugz modify 130608 --invalid -c "Not reproducable"
 
+5) We can post a bug by simply invoking
+
+$bugz post
+This command will guide you through the bug creation process. However,
+this does not support custom fields. 
+
+For creating a bug with custom fields, you can could use the template support:
+$bugz post --template pybugz.tmpl 
+
+You can modify the supplied template file (or create one) to suit your needs.
+
 Other options
 -------------
 

--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 import textwrap
 import xmlrpc.client
+import configparser
 
 try:
     import readline
@@ -551,18 +552,82 @@ def post(settings):
             raise BugzError('Unable to read from file: %s: %s' %
                             (settings.description_from, error))
 
-    if not hasattr(settings, 'batch'):
+    if not hasattr(settings, 'batch') and not hasattr(settings, 'template'):
         prompt_for_bug(settings)
 
-    # raise an exception if mandatory fields are not specified.
-    if not hasattr(settings, 'product'):
-        raise RuntimeError('Product not specified')
-    if not hasattr(settings, 'component'):
-        raise RuntimeError('Component not specified')
-    if not hasattr(settings, 'summary'):
-        raise RuntimeError('Title not specified')
-    if not hasattr(settings, 'description'):
-        raise RuntimeError('Description not specified')
+    params = {}
+
+    if hasattr(settings, 'template'):
+        tmpl = configparser.RawConfigParser()
+        tmpl.optionxform = lambda option: option
+        tmpl.read(settings.template)
+        try:
+            msection = tmpl['Default']['type']
+            for key in tmpl[msection]:
+                try:
+                    params[key] = tmpl[msection][key]
+                    print('%-12s: %s' % (key, params[key]))
+                except:
+                    print('Could not parse %s!' % key) 
+        except:
+           printf('Could not parse Default type!')  
+    else:
+        # raise an exception if mandatory fields are not specified.
+        if not hasattr(settings, 'product'):
+            raise RuntimeError('Product not specified')
+        if not hasattr(settings, 'component'):
+            raise RuntimeError('Component not specified')
+        if not hasattr(settings, 'summary'):
+            raise RuntimeError('Title not specified')
+        if not hasattr(settings, 'description'):
+            raise RuntimeError('Description not specified')
+        print('-' * (settings.columns - 1))
+        print('%-12s: %s' % ('Product', settings.product))
+        print('%-12s: %s' % ('Component', settings.component))
+        print('%-12s: %s' % ('Title', settings.summary))
+        if hasattr(settings, 'version'):
+            print('%-12s: %s' % ('Version', settings.version))
+        print('%-12s: %s' % ('Description', settings.description))
+        if hasattr(settings, 'op_sys'):
+            print('%-12s: %s' % ('Operating System', settings.op_sys))
+        if hasattr(settings, 'platform'):
+            print('%-12s: %s' % ('Platform', settings.platform))
+        if hasattr(settings, 'priority'):
+            print('%-12s: %s' % ('Priority', settings.priority))
+        if hasattr(settings, 'severity'):
+            print('%-12s: %s' % ('Severity', settings.severity))
+        if hasattr(settings, 'alias'):
+            print('%-12s: %s' % ('Alias', settings.alias))
+        if hasattr(settings, 'assigned_to'):
+            print('%-12s: %s' % ('Assigned to', settings.assigned_to))
+        if hasattr(settings, 'cc'):
+            print('%-12s: %s' % ('CC', settings.cc))
+        if hasattr(settings, 'url'):
+            print('%-12s: %s' % ('URL', settings.url))
+        print('-' * (settings.columns - 1))
+        params['product'] = settings.product
+        params['component'] = settings.component
+        if hasattr(settings, 'version'):
+            params['version'] = settings.version
+        params['summary'] = settings.summary
+        if hasattr(settings, 'description'):
+            params['description'] = settings.description
+        if hasattr(settings, 'op_sys'):
+            params['op_sys'] = settings.op_sys
+        if hasattr(settings, 'platform'):
+            params['platform'] = settings.platform
+        if hasattr(settings, 'priority'):
+            params['priority'] = settings.priority
+        if hasattr(settings, 'severity'):
+            params['severity'] = settings.severity
+        if hasattr(settings, 'alias'):
+            params['alias'] = settings.alias
+        if hasattr(settings, 'assigned_to'):
+            params['assigned_to'] = settings.assigned_to
+        if hasattr(settings, 'cc'):
+            params['cc'] = settings.cc
+        if hasattr(settings, 'url'):
+            params['url'] = settings.url
 
     # append the output from append_command to the description
     append_command = getattr(settings, 'append_command', None)
@@ -571,35 +636,6 @@ def post(settings):
         settings.description = settings.description + '\n\n' + \
             '$ ' + append_command + '\n' + \
             append_command_output
-
-    # print submission confirmation
-    print('-' * (settings.columns - 1))
-    print('%-12s: %s' % ('Product', settings.product))
-    print('%-12s: %s' % ('Component', settings.component))
-    print('%-12s: %s' % ('Title', settings.summary))
-    if hasattr(settings, 'version'):
-        print('%-12s: %s' % ('Version', settings.version))
-    print('%-12s: %s' % ('Description', settings.description))
-    if hasattr(settings, 'op_sys'):
-        print('%-12s: %s' % ('Operating System', settings.op_sys))
-    if hasattr(settings, 'platform'):
-        print('%-12s: %s' % ('Platform', settings.platform))
-    if hasattr(settings, 'priority'):
-        print('%-12s: %s' % ('Priority', settings.priority))
-    if hasattr(settings, 'severity'):
-        print('%-12s: %s' % ('Severity', settings.severity))
-    if hasattr(settings, 'alias'):
-        print('%-12s: %s' % ('Alias', settings.alias))
-    if hasattr(settings, 'assigned_to'):
-        print('%-12s: %s' % ('Assigned to', settings.assigned_to))
-    if hasattr(settings, 'cc'):
-        print('%-12s: %s' % ('CC', settings.cc))
-    if hasattr(settings, 'url'):
-        print('%-12s: %s' % ('URL', settings.url))
-    # fixme: groups
-    # fixme: status
-    # fixme: Milestone
-    print('-' * (settings.columns - 1))
 
     if not hasattr(settings, 'batch'):
         if settings.default_confirm in ['Y', 'y']:
@@ -612,30 +648,6 @@ def post(settings):
             log_info('Submission aborted')
             return
 
-    params = {}
-    params['product'] = settings.product
-    params['component'] = settings.component
-    if hasattr(settings, 'version'):
-        params['version'] = settings.version
-    params['summary'] = settings.summary
-    if hasattr(settings, 'description'):
-        params['description'] = settings.description
-    if hasattr(settings, 'op_sys'):
-        params['op_sys'] = settings.op_sys
-    if hasattr(settings, 'platform'):
-        params['platform'] = settings.platform
-    if hasattr(settings, 'priority'):
-        params['priority'] = settings.priority
-    if hasattr(settings, 'severity'):
-        params['severity'] = settings.severity
-    if hasattr(settings, 'alias'):
-        params['alias'] = settings.alias
-    if hasattr(settings, 'assigned_to'):
-        params['assigned_to'] = settings.assigned_to
-    if hasattr(settings, 'cc'):
-        params['cc'] = settings.cc
-    if hasattr(settings, 'url'):
-        params['url'] = settings.url
 
     result = settings.call_bz(settings.bz.Bug.create, params)
     log_info('Bug %d submitted' % result['id'])

--- a/bugz/cli_argparser.py
+++ b/bugz/cli_argparser.py
@@ -256,6 +256,8 @@ def make_arg_parser():
     post_parser.add_argument('--batch',
                              action="store_true",
                              help='do not prompt for any values')
+    post_parser.add_argument('--template',
+                             help='Use a template file for posting bugs')
     post_parser.add_argument('--default-confirm',
                              choices=['y', 'Y', 'n', 'N'],
                              default='y',

--- a/pybugz.tmpl
+++ b/pybugz.tmpl
@@ -1,0 +1,14 @@
+[Default]
+type: myfeature 
+
+[myfeature]
+product: Platform
+component: featureX 
+version: unspecified
+assigned_to: example@example.com 
+qa_contact: example2@example.com 
+cc: example3@example.com 
+cf_which_version: 14.31 
+summary: Feature summary  
+description: This is a multiline description of the 
+	the bug. you can add custom details here.


### PR DESCRIPTION
A new bug can now be created using the supplied
template file. The template file needs to contain
all the required parameters needed by bugzilla.

Optional fields can also be supplied.