### PR TITLE
cli: Accept multiple bugid args for get, modify

### DIFF
--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -408,11 +408,14 @@ def get(settings):
     check_auth(settings)
 
     log_info('Getting bug %s ..' % settings.bugid)
-    params = {'ids': [settings.bugid]}
+    params = {'ids': settings.bugid}
     result = settings.call_bz(settings.bz.Bug.get, params)
 
-    for bug in result['bugs']:
+    bugCount = len(result['bugs'])
+    for idx, bug in enumerate(result['bugs']):
         show_bug_info(bug, settings)
+        if idx + 1 != bugCount:
+            print()
 
 
 def modify(settings):
@@ -435,7 +438,7 @@ def modify(settings):
         settings.comment = block_edit('Enter comment:')
 
     params = {}
-    params['ids'] = [settings.bugid]
+    params['ids'] = settings.bugid
     if hasattr(settings, 'alias'):
         params['alias'] = settings.alias
     if hasattr(settings, 'assigned_to'):

--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -87,6 +87,7 @@ def check_auth(settings):
 
 
 def list_bugs(buglist, settings):
+    maxbug = max([len(str(bug['id'])) for bug in buglist])
     for bug in buglist:
         bugid = bug['id']
         status = bug['status']
@@ -94,7 +95,7 @@ def list_bugs(buglist, settings):
         severity = bug['severity']
         assignee = bug['assigned_to'].split('@')[0]
         desc = bug['summary']
-        line = '%s' % (bugid)
+        line = '%-*s' % (maxbug, bugid)
         if hasattr(settings, 'show_status'):
             line = '%s %-12s' % (line, status)
         if hasattr(settings, 'show_priority'):
@@ -411,11 +412,16 @@ def get(settings):
     params = {'ids': settings.bugid}
     result = settings.call_bz(settings.bz.Bug.get, params)
 
-    bugCount = len(result['bugs'])
-    for idx, bug in enumerate(result['bugs']):
-        show_bug_info(bug, settings)
-        if idx + 1 != bugCount:
-            print()
+    bugs = result['bugs']
+    if settings.summary:
+        settings.show_status = True
+        list_bugs(bugs, settings)
+    else:
+       bugCount = len(bugs)
+       for idx, bug in enumerate(bugs):
+           show_bug_info(bug, settings)
+           if idx + 1 != bugCount:
+               print()
 
 
 def modify(settings):

--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -26,6 +26,7 @@ import textwrap
 import xmlrpc.client
 
 try:
+    # pylint: disable=unused-import
     import readline
 except ImportError:
     pass
@@ -129,7 +130,7 @@ def prompt_for_bug(settings):
 
     if not hasattr(settings, 'version'):
         line = input('Enter version (default: unspecified): ')
-        if len(line):
+        if line:
             settings.version = line
         else:
             settings.version = 'unspecified'
@@ -146,7 +147,7 @@ def prompt_for_bug(settings):
 
     if not hasattr(settings, 'description'):
         line = block_edit('Enter bug description: ')
-        if len(line):
+        if line:
             settings.description = line
     else:
         log_info('Enter bug description: %s' % settings.description)
@@ -154,7 +155,7 @@ def prompt_for_bug(settings):
     if not hasattr(settings, 'op_sys'):
         op_sys_msg = 'Enter operating system where this bug occurs: '
         line = input(op_sys_msg)
-        if len(line):
+        if line:
             settings.op_sys = line
     else:
         log_info('Enter operating system: %s' % settings.op_sys)
@@ -162,7 +163,7 @@ def prompt_for_bug(settings):
     if not hasattr(settings, 'platform'):
         platform_msg = 'Enter hardware platform where this bug occurs: '
         line = input(platform_msg)
-        if len(line):
+        if line:
             settings.platform = line
     else:
         log_info('Enter hardware platform: %s' % settings.platform)
@@ -170,7 +171,7 @@ def prompt_for_bug(settings):
     if not hasattr(settings, 'priority'):
         priority_msg = 'Enter priority (eg. Normal) (optional): '
         line = input(priority_msg)
-        if len(line):
+        if line:
             settings.priority = line
     else:
         log_info('Enter priority (optional): %s' % settings.priority)
@@ -178,7 +179,7 @@ def prompt_for_bug(settings):
     if not hasattr(settings, 'severity'):
         severity_msg = 'Enter severity (eg. normal) (optional): '
         line = input(severity_msg)
-        if len(line):
+        if line:
             settings.severity = line
     else:
         log_info('Enter severity (optional): %s' % settings.severity)
@@ -186,7 +187,7 @@ def prompt_for_bug(settings):
     if not hasattr(settings, 'alias'):
         alias_msg = 'Enter an alias for this bug (optional): '
         line = input(alias_msg)
-        if len(line):
+        if line:
             settings.alias = line
     else:
         log_info('Enter alias (optional): %s' % settings.alias)
@@ -194,7 +195,7 @@ def prompt_for_bug(settings):
     if not hasattr(settings, 'assigned_to'):
         assign_msg = 'Enter assignee (eg. liquidx@gentoo.org) (optional): '
         line = input(assign_msg)
-        if len(line):
+        if line:
             settings.assigned_to = line
     else:
         log_info('Enter assignee (optional): %s' % settings.assigned_to)
@@ -202,7 +203,7 @@ def prompt_for_bug(settings):
     if not hasattr(settings, 'cc'):
         cc_msg = 'Enter a CC list (comma separated) (optional): '
         line = input(cc_msg)
-        if len(line):
+        if line:
             settings.cc = re.split(r',\s*', line)
     else:
         log_info('Enter a CC list (optional): %s' % settings.cc)
@@ -210,7 +211,7 @@ def prompt_for_bug(settings):
     if not hasattr(settings, 'url'):
         url_msg = 'Enter a URL (optional): '
         line = input(url_msg)
-        if len(line):
+        if line:
             settings.url = line
     else:
         log_info('Enter a URL (optional): %s' % settings.url)
@@ -224,7 +225,7 @@ def prompt_for_bug(settings):
     if not hasattr(settings, 'append_command'):
         line = input('Append the output of the'
                      ' following command (leave blank for none): ')
-        if len(line):
+        if line:
             settings.append_command = line
     else:
         log_info('Append command (optional): %s' % settings.append_command)
@@ -284,10 +285,10 @@ def show_bug_info(bug, settings):
         bug_attachments = bug_attachments['bugs']['%s' % bug['id']]
         print('%-12s: %d' % ('Attachments', len(bug_attachments)))
         print()
-        for attachment in bug_attachments:
-            aid = attachment['id']
-            desc = attachment['summary']
-            when = attachment['creation_time']
+        for attach_val in bug_attachments:
+            aid = attach_val['id']
+            desc = attach_val['summary']
+            when = attach_val['creation_time']
             print('[Attachment] [%s] [%s]' % (aid, desc))
 
     if not hasattr(settings, 'no_comments'):
@@ -528,7 +529,7 @@ def modify(settings):
     result = settings.call_bz(settings.bz.Bug.update, params)
     for bug in result['bugs']:
         changes = bug['changes']
-        if not len(changes):
+        if not changes:
             log_info('Added comment to bug %s' % bug['id'])
         else:
             log_info('Modified the following fields in bug %s' % bug['id'])
@@ -543,10 +544,10 @@ def post(settings):
     # load description from file if possible
     if hasattr(settings, 'description_from'):
         try:
-                if settings.description_from == '-':
-                    settings.description = sys.stdin.read()
-                else:
-                    settings.description = \
+            if settings.description_from == '-':
+                settings.description = sys.stdin.read()
+            else:
+                settings.description = \
                         open(settings.description_from, 'r').read()
         except IOError as error:
             raise BugzError('Unable to read from file: %s: %s' %
@@ -568,7 +569,7 @@ def post(settings):
     # append the output from append_command to the description
     append_command = getattr(settings, 'append_command', None)
     if append_command is not None and append_command != '':
-        append_command_output = subprocess.getoutput(append_command)
+        append_command_output = subprocess.getoutput(append_command) # pylint: disable=no-member
         settings.description = settings.description + '\n\n' + \
             '$ ' + append_command + '\n' + \
             append_command_output
@@ -673,7 +674,7 @@ the keywords given on the title (or the body if specified).
 
     result = settings.call_bz(settings.bz.Bug.search, params)['bugs']
 
-    if not len(result):
+    if not result:
         log_info('No bugs found.')
     else:
         list_bugs(result, settings)

--- a/bugz/cli_argparser.py
+++ b/bugz/cli_argparser.py
@@ -215,9 +215,9 @@ def make_arg_parser():
     modify_parser.add_argument('-U', '--url',
                                help='set URL field of bug')
     modify_parser.add_argument('-v', '--version',
-                               help='set the version for this bug'),
+                               help='set the version for this bug')
     modify_parser.add_argument('-w', '--whiteboard',
-                               help='set Status whiteboard'),
+                               help='set Status whiteboard')
     modify_parser.add_argument('--fixed',
                                action='store_true',
                                help='mark bug as RESOLVED, FIXED')

--- a/bugz/cli_argparser.py
+++ b/bugz/cli_argparser.py
@@ -103,6 +103,9 @@ def make_arg_parser():
     get_parser.add_argument("-n", "--no-comments",
                             action="store_true",
                             help='do not show comments')
+    get_parser.add_argument("-s", "--summary",
+                            action="store_true",
+                            help='show only minimal details, one bug per line')
     get_parser.set_defaults(func=bugz.cli.get)
 
     modify_parser = subparsers.add_parser('modify',

--- a/bugz/cli_argparser.py
+++ b/bugz/cli_argparser.py
@@ -95,6 +95,7 @@ def make_arg_parser():
                                        argument_default=argparse.SUPPRESS,
                                        help='get a bug from bugzilla')
     get_parser.add_argument('bugid',
+                            nargs='+',
                             help='the ID of the bug to retrieve')
     get_parser.add_argument("-a", "--no-attachments",
                             action="store_true",
@@ -109,6 +110,7 @@ def make_arg_parser():
                                           help='modify a bug '
                                           '(eg. post a comment)')
     modify_parser.add_argument('bugid',
+                               nargs='+',
                                help='the ID of the bug to modify')
     modify_parser.add_argument('--alias',
                                help='change the alias for this bug')

--- a/bugz/settings.py
+++ b/bugz/settings.py
@@ -93,6 +93,13 @@ class Settings:
                 self.quiet = False
         log_setQuiet(self.quiet)
 
+        if not hasattr(self, 'summary'):
+            if config.has_option(self.connection, 'summary'):
+                self.summary = get_config_option(config.getboolean,
+                                                 self.connection, 'summary')
+            else:
+                self.summary = False
+
         if not hasattr(self, 'search_statuses'):
             if config.has_option(self.connection, 'search_statuses'):
                 s = get_config_option(config.get, self.connection,


### PR DESCRIPTION
Since the bugzilla API can easily handle multiple bugs for a single
action, just extend the parser to allow multiples for bugid, and pass it
properly to the query.

I've also cleaned up pylint for the modified files to have a clean slate,
and changed `show_bug_info` to display the bug fields in a well-defined,
and consistent, order.