### PR TITLE
Support --columns 0 which disables column limiting

### DIFF
--- a/bugz/cli.py
+++ b/bugz/cli.py
@@ -101,7 +101,7 @@ def list_bugs(buglist, settings):
             line = '%s %-12s' % (line, severity)
         line = '%s %-20s' % (line, assignee)
         line = '%s %s' % (line, desc)
-        print(line[:settings.columns])
+        print(line[:settings.columns] if settings.columns else line)
 
     log_info("%i bug(s) found." % len(buglist))
 


### PR DESCRIPTION
Setting the columns to "unlimited" can be necessary when piping the output of bugz:

```
pybugz $ ./lbugz search pybugz
 * Info: Using [Gentoo] (https://bugs.gentoo.org/xmlrpc.cgi)
 * Info: Searching for bugs meeting the following criteria:
 * Info:    status               = ['CONFIRMED', 'IN_PROGRESS', 'UNCONFIRMED']
 * Info:    summary              = ['pybugz']
479422 williamh             www-client/pybugz needs templates for new bugs
604826 williamh             www-client/pybugz - bugz search -C Stabilization -C Keywording: UnicodeEncodeError: 'ascii' codec can't encode character '\u2008' in position 55: ordinal not in range(128)
 * Info: 2 bug(s) found.
pybugz $ ./lbugz search pybugz | cat -
 * Info: Using [Gentoo] (https://bugs.gentoo.org/xmlrpc.cgi)
 * Info: Searching for bugs meeting the following criteria:
 * Info:    status               = ['CONFIRMED', 'IN_PROGRESS', 'UNCONFIRMED']
 * Info:    summary              = ['pybugz']
479422 williamh             www-client/pybugz needs templates for new bugs
604826 williamh             www-client/pybugz - bugz search -C Stabilization -C
 * Info: 2 bug(s) found.
pybugz $ ./lbugz --columns 0 search pybugz | cat -
 * Info: Using [Gentoo] (https://bugs.gentoo.org/xmlrpc.cgi)
 * Info: Searching for bugs meeting the following criteria:
 * Info:    status               = ['CONFIRMED', 'IN_PROGRESS', 'UNCONFIRMED']
 * Info:    summary              = ['pybugz']
479422 williamh             www-client/pybugz needs templates for new bugs
604826 williamh             www-client/pybugz - bugz search -C Stabilization -C Keywording: UnicodeEncodeError: 'ascii' codec can't encode character '\u2008' in position 55: ordinal not in range(128)
 * Info: 2 bug(s) found.
```