### PR TITLE
Query limit to be configurable

### DIFF
--- a/bugz/settings.py
+++ b/bugz/settings.py
@@ -123,6 +123,11 @@ class Settings:
             else:
                 self.insecure = False
 
+        if not hasattr(self, 'limit'):
+            if config.has_option(self.connection, 'limit'):
+                self.limit = get_config_option(config.get, self.connection,
+                                               'limit')
+
         if getattr(self, 'encoding', None) is not None:
             log_info('The encoding option is deprecated.')
 

--- a/pybugz.d/redhat.conf
+++ b/pybugz.d/redhat.conf
@@ -1,3 +1,5 @@
 [RedHat]
 base = https://bugzilla.redhat.com/xmlrpc.cgi
 search_statuses = NEW, ASSIGNED, MODIFIED, ON_DEV, POST
+interactive = True
+limit = 1000


### PR DESCRIPTION
Red Hat Bugzilla applied policy that anonymous queries can get at most
20 lines in the API output, and authenticated queries up to 1000.

So it is probably a good idea to "push" Red Hat maintainers to the
authentication (interactive=True) a little bit more and set some
reasonable default limit (limit=1000), otherwise the output will be very
limited (and there's a risk that user misses some bugs thinking that the
output is complete).

Both of those options can be changed in $HOME/.bugzrc.