### PR TITLE
docs: fix simple typo, loggig -> logging

### DIFF
--- a/bugz/log.py
+++ b/bugz/log.py
@@ -1,6 +1,6 @@
 """ This module contains a set of routines for logging messages.
 
-    If someone wants to convert this to use python's built-in loggig,
+    If someone wants to convert this to use python's built-in logging,
     patches are welcome.
 """
 


### PR DESCRIPTION
There is a small typo in bugz/log.py.

Should read `logging` rather than `loggig`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md